### PR TITLE
--enable-obsolete-nsl

### DIFF
--- a/glibc/compile
+++ b/glibc/compile
@@ -18,6 +18,7 @@ UB_CONFIGURE_DIR="$UB_COMPILEDIR" ub_configure \
 	--enable-bind-now \
 	--disable-profile \
 	--enable-lock-elision \
+	--enable-obsolete-nsl \
 	--disable-werror \
 	libc_cv_slibdir=/lib
 else
@@ -28,7 +29,8 @@ UB_CONFIGURE_DIR="$UB_COMPILEDIR" ub_configure \
 	--enable-kernel=2.6.33 \
 	--enable-obsolete-rpc \
 	--with-cpu=i686 \
-	--disable-werror
+	--disable-werror \
+	--enable-obsolete-nsl
 fi
 
 # glibc doesn't like -Os!


### PR DESCRIPTION
* The NIS(+) name service modules, libnss_nis, libnss_nisplus, and
  libnss_compat, are deprecated, and will not be built or installed by
  default.

  The NIS(+) support library, libnsl, is also deprecated.  By default, a
  compatibility shared library will be built and installed, but not headers
  or development libraries. Only a few NIS-related programs require this
  library.  (In particular, the GNU C Library has never required programs
  that use 'gethostbyname' to be linked with libnsl.)

  Replacement implementations based on TIRPC, which additionally support
  IPv6, are available from <https://github.com/thkukuk/>.  The configure
  option --enable-obsolete-nsl will cause libnsl's headers, and the NIS(+)
  name service modules, to be built and installed.